### PR TITLE
GeoTrace: Ask for confirmation before discarding with the Back button

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,4 @@ Note that this change might cause problems with other Java-based applications (e
 If you encounter the `java.lang.NullPointerException (no error message).` when running `gradlew`, please make sure your Java version for this project is Java 8.
 
 This can be configured under **File > Project Structure** in Android Studio, or by editing `$USER_HOME/.gradle/gradle.properties` to set `org.gradle.java.home=(path to JDK home)` for command-line use.
+


### PR DESCRIPTION
Closes: See [ODK Collect Geo roadmap specification](https://docs.google.com/document/d/1r3wJrOVDeFQkk4kWMoW29LtLI1vbBChqJ65w1Jyg4YU/edit).
Risk: Low
Code scope: GeoTraceActivity
UX scope: GeoTrace (Back button)

- [x] `./gradlew checkCode` passed
- [x] UI elements follow [style guidelines](http://bit.ly/2XtluID)

Requested reviewers: @zestyping 

#### Overview

Previously, the Back button would immediately exit the GeoTraceActivity, discarding all edits made while in the activity without warning.  To prevent accidental loss of work, this PR adds a confirmation dialog.

#### User-visible changes

GeoTraceActivity now asks for confirmation when the Back button is pressed, if there have been edits made in the GeoTraceActivity that would be discarded.

The criterion for showing the confirmation dialog is not the _presence_ of data, but a change in the data.  So if there was nothing recorded, recording anything new constitutes a change that requires confirmation before discarding it.  If there was something recorded, then deleting it constitutes a change that requires confirmation before discarding the deletion.

#### Guidance for reviewers

This PR is based on top of another PR.  The only change that needs to be reviewed is the last commit, https://github.com/opendatakit/collect/pull/2838/commits/be682acc04cf4373e7de814029a3803fef8c7480.

#### Verification performed

I tried launching the GeoTraceActivity with no prior data entered; then:
- I manually added one point
- I tapped the Back button; the confirmation dialog appeared as expected
- I manually added a second point
- I tapped the Back button; the confirmation dialog appeared as expected
- I manually added a third point
- I tapped the Back button; the confirmation dialog appeared as expected
- I used the Trash button to clear the points
- I tapped the Back button; the confirmation dialog did not appear, as expected

I then tried launching the GeoTraceActivity with prior trace data present; then:
- I tapped the Back button; the confirmation dialog did not appear, as expected
- I launched again, then used the Trash button to clear the points
- I tapped the Back button; the confirmation dialog appeared as expected