### PR TITLE
Google Sheets: Remove 256-column limit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,5 @@ Note that this change might cause problems with other Java-based applications (e
 If you encounter the `java.lang.NullPointerException (no error message).` when running `gradlew`, please make sure your Java version for this project is Java 8.
 
 This can be configured under **File > Project Structure** in Android Studio, or by editing `$USER_HOME/.gradle/gradle.properties` to set `org.gradle.java.home=(path to JDK home)` for command-line use.
+
+


### PR DESCRIPTION
Closes: #2888
Risk: Low
Code scope: InstanceGoogleSheetsUploader
- [x] `./gradlew checkCode` passed

Requested reviewers: @zestyping

#### User-visible changes <!-- Required.  If no user-visible changes, write "None." -->

No UI impact.  Forms with more than 256 columns can now be sent to Google Sheets.

#### Verification performed <!-- What has been done to ensure this works?  Okay to omit for documentation-only PRs. -->

I tested a form with one thousand questions: [OneThousandQuestions.xml.txt](https://github.com/opendatakit/collect/files/2921433/OneThousandQuestions.xml.txt)